### PR TITLE
bug fix: fix auth node check when it does not contain IOTHUB_DEVICE_D…

### DIFF
--- a/Armadillo-IoT_GW/modules/azure/model_config_base.py
+++ b/Armadillo-IoT_GW/modules/azure/model_config_base.py
@@ -65,6 +65,9 @@ class ModelConfigBase:
             elif not ModelConfigBase._is_valid_auth_conf(value):
                 print("Error! invalid auth conf.")
                 return False
+            if not value.get(ModelConfigBase.IOTHUB_DEVICE_DPS_ENDPOINT):
+                value[ModelConfigBase.IOTHUB_DEVICE_DPS_ENDPOINT] = \
+                    "global.azure-devices-provisioning.net"
             return True
         elif (name in [ModelConfigBase.SEND_INTERVAL, ModelConfigBase.THERMAL_SENSE_INTERVAL]):
             if not isinstance(value, int):
@@ -92,8 +95,9 @@ class ModelConfigBase:
 
     @staticmethod
     def _is_valid_auth_conf(value):
-        if not value.get(ModelConfigBase.IOTHUB_DEVICE_DPS_ENDPOINT):
-            value.put(ModelConfigBase.IOTHUB_DEVICE_DPS_ENDPOINT, "global.azure-devices-provisioning.net")
+        if value.get(ModelConfigBase.IOTHUB_DEVICE_DPS_ENDPOINT) is None:
+            print("Error! IOTHUB_DEVICE_DPS_ENDPOINT not found")
+            return False
         elif not value.get(ModelConfigBase.IOTHUB_DEVICE_DPS_ID_SCOPE):
             print("Error! IOTHUB_DEVICE_DPS_ID_SCOPE not found")
             return False


### PR DESCRIPTION
_is_valid_auth_conf() の件です。

以下の仕様にしました。
- "IOTHUB_DEVICE_DPS_ENDPOINT": "global.azure-devices-provisioning.net", -> 正常
- "IOTHUB_DEVICE_DPS_ENDPOINT": "",　-> 自動的に値を入れる
- "IOTHUB_DEVICE_DPS_ENDPOINT" がない -> エラー
